### PR TITLE
parallel option for tox not guaranteed in lxc environment

### DIFF
--- a/src/review_gator/tox_runner.py
+++ b/src/review_gator/tox_runner.py
@@ -37,7 +37,7 @@ def run_tox(source_repo, source_branch, output_directory=None, mp_id=None,
             source_repo,
             source_branch,
             tox_command='tox --recreate --parallel auto -q'
-            if parallel_tox else 'tox --recreate',
+            if parallel_tox and environment is None else 'tox --recreate',
             output_filepath=tox_output,
             environment=environment)
     except git.exc.GitCommandError as git_exc:


### PR DESCRIPTION
`--parallel` was introduced in tox v 3.7.0 but the most comment environment used for tox tests in our
use cases is 18.04.

In 18.04 the version of tox in the archive is 2.5 so to be safe we should disable parallel tox when
running in an lxc environment

[1] https://tox.readthedocs.io/en/latest/changelog.html#v3-7-0-2019-01-11
[2] https://people.canonical.com/~ubuntu-archive/madison.cgi?package=tox&a=&c=&s=