### PR TITLE
Revert "parallel option for tox not guaranteed in lxc environment"

### DIFF
--- a/src/review_gator/tox_runner.py
+++ b/src/review_gator/tox_runner.py
@@ -37,7 +37,7 @@ def run_tox(source_repo, source_branch, output_directory=None, mp_id=None,
             source_repo,
             source_branch,
             tox_command='tox --recreate --parallel auto -q'
-            if parallel_tox and environment is None else 'tox --recreate',
+            if parallel_tox else 'tox --recreate',
             output_filepath=tox_output,
             environment=environment)
     except git.exc.GitCommandError as git_exc:


### PR DESCRIPTION
This was needlessly removed as lpshipit now has fixed the bug where
newer versions of tox can be installed even behind a proxy.

This reverts commit f4649681c5e14a8e008d2d685dc867d0726924e8.