### PR TITLE
Conditional install of gitpython based on python version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -9,5 +9,7 @@ PyGithub
 lpshipit>=0.4
 joblib
 GitPython
+GitPython<3.1.15; python_version < "3.6"
+GitPython; python_version >= "3.6"
 tox
 launchpadlib


### PR DESCRIPTION
GitPython 3.1.15 dropped support for python 3.5. Using environment markers we can
install an older version on systems with python 3.5 or less.