### PR TITLE
Feat: include top commit line in MP titles

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -370,7 +370,11 @@ def render(repos, output_directory, tox):
 
 def get_mp_title(mp):
     '''Format a sensible MP title from git branches and the description.'''
-    title = ''
+    header = '(no commit message)'
+
+    if mp.commit_message is not None and len(mp.commit_message) > 0:
+        header = mp.commit_message.split('\n')[0]
+    title = header + '\n\n'
     git_source = mp.source_git_path
     if git_source is not None:
         source = '<strong>'

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -540,7 +540,7 @@ def get_lp_repos(sources, output_directory=None, lp_credentials_store=None):
         except AttributeError:
             print_warning(
                 ["COULD NOT FIND REPO : {}".format(source),
-                 "SKIPPING {}"].format(source)
+                 "SKIPPING {}".format(source)]
             )
             continue
         repo.tox = data.get('tox', False)
@@ -728,7 +728,7 @@ def main(config_skeleton, config, output_directory,
     if config_skeleton:
         with open(resource_filename(
                 'review_gator', 'config-skeleton.yaml'), 'r') as config_file:
-            package_config = yaml.load(config_file)
+            package_config = yaml.safe_load(config_file)
 
             output = yaml.dump(package_config, Dumper=yaml.Dumper)
             print("# Sample config.")

--- a/src/review_gator/templates/reviews.html
+++ b/src/review_gator/templates/reviews.html
@@ -70,7 +70,7 @@
             {% for pull_request in repo.pull_requests %}
                 <tr data-state="{{ pull_request.state|lower }}" data-dedicated-tab="{{ repo.tab_name }}">
                     <td data-order="{{ repo.repo_name }}" title="{{ repo.repo_name }}"><a href="{{ repo.repo_url }}">{{ repo.repo_shortname }}</a></td>
-                    <td><a href="{{ pull_request.url }}">{{ pull_request.title }}</a></td>
+                    <td style="white-space:pre-wrap;"><a href="{{ pull_request.url }}">{{ pull_request.title }}</a></td>
                     <td>{{ pull_request.state }}</td>
                     <td>{{ pull_request.owner }}</td>
                     <td data-order="{{ pull_request.latest_activity }}">{{ pull_request.latest_activity_age }}</td>


### PR DESCRIPTION
This PR prepends the first line of an MP's commit message to the MP title as rendered in the "Merge Proposals" column of Review Gator.

The purpose of this change is to improve Review Gator's UX via the addition of helpful info.

There are also a couple of minor syntax fixes in this PR.