### PR TITLE
feat: mark Approvals older than proposed HEAD as stale

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -470,7 +470,7 @@ def get_mps(repo, branch, output_directory=None):
                     tmpdir = tempfile.TemporaryDirectory()
                     cloned_repo = get_git_repo(src_git_repo, mp.source_git_path.replace('refs/heads/', ''), tmpdir)
                     cloned_head_date = cloned_repo.head.commit.committed_datetime
-                    if review_date < cloned_head_date and result.lower() in ['approve', 'approved']:
+                    if review_date < cloned_head_date:
                         result += '-STALE'
             except lazr.restfulclient.errors.NotFound as comment_not_found_exception:
                 print("Warning: MP ({}) could not find comment for vote from {} - "

--- a/src/review_gator/templates/reviews.html
+++ b/src/review_gator/templates/reviews.html
@@ -80,6 +80,7 @@
                             <tbody>
                                 {% for review in pull_request.reviews %}
                                 <tr {% if review.state == 'Approve' or review.state == 'APPROVED' %}class="success"{% endif %}
+                                    {% if review.state == 'Approve-STALE' or review.state == 'APPROVED-STALE' %}class="danger"{% endif %}
                                     {% if review.state == 'Disapprove' or review.state == 'Needs Fixing' or review.state == "CHANGES_REQUESTED" or review.state == "Resubmit" %}class="danger"{% endif %}
                                     {% if review.state == 'Needs Information' or review.state == 'COMMENTED' %}class="warning"{% endif %}>
                                     <td>{{ review.owner }}</td>


### PR DESCRIPTION
This PR changes how Approvals appear in the Reviews column. Namely, if an Approval is older than the date of HEAD, then:

* `-STALE` will be appended to the word "Approve" (or "APPROVED")
* the cell will be marked as red to visually indicate a new review should occur

Note that because of apparent limitations of the Launchpad API, a shallow git clone of the source branch is required, which adds a bit of performance overhead.