### PR TITLE
Fix: Revert #18 and use lp: instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ pip install -e .
 GITHUB_TOKEN=... review-gator --config branches.yaml
 ```
 
+### Prerequisites
+
+In order to function with Launchpad git repositories, the host must
+have a `.gitconfig` with Launchpad username and `lp:` substitution set up.
+See the following guide for instructions on setting up git for Launchpad:
+https://help.launchpad.net/Code/Git#Configuring_Git
+
 Basic Configuration
 -------------------
 

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -465,7 +465,7 @@ def get_mps(repo, branch, output_directory=None):
 
                     src_git_repo = mp.source_git_repository_link.replace(
                         'https://api.launchpad.net/devel/',
-                        'https://git.launchpad.net/')
+                        'lp:')
 
                     tmpdir = tempfile.TemporaryDirectory()
                     cloned_repo = get_git_repo(src_git_repo, mp.source_git_path.replace('refs/heads/', ''), tmpdir)

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -430,7 +430,7 @@ def get_git_repo(path, checkout, tmpdir):
 
     return cloned_repo
 
-def get_mps(repo, branch, output_directory=None, lp_username=None):
+def get_mps(repo, branch, output_directory=None):
     '''Return all merge proposals for the given branch.'''
     mps = get_candidate_mps(branch)
     tox_mps = []
@@ -465,7 +465,7 @@ def get_mps(repo, branch, output_directory=None, lp_username=None):
 
                     src_git_repo = mp.source_git_repository_link.replace(
                         'https://api.launchpad.net/devel/',
-                        f'git+ssh://{lp_username}@git.launchpad.net/')
+                        'https://git.launchpad.net/')
 
                     tmpdir = tempfile.TemporaryDirectory()
                     cloned_repo = get_git_repo(src_git_repo, mp.source_git_path.replace('refs/heads/', ''), tmpdir)
@@ -546,7 +546,7 @@ def get_branches(sources, lp_credentials_store=None):
     return repos
 
 
-def get_lp_repos(sources, output_directory=None, lp_credentials_store=None, lp_username=None):
+def get_lp_repos(sources, output_directory=None, lp_credentials_store=None):
     '''Return all repos, prs and reviews for the given lp-git source.'''
     # deferred import of launchpadagent until required
     from . import launchpadagent
@@ -571,7 +571,7 @@ def get_lp_repos(sources, output_directory=None, lp_credentials_store=None, lp_u
         repo.parallel_tox = data.get('parallel-tox', True)
         repo.environment = data.get('environment', None)
         repo.tab_name = data.get('tab-name', None)
-        get_mps(repo, b, output_directory, lp_username)
+        get_mps(repo, b, output_directory)
         if repo.pull_request_count > 0:
             repos.append(repo)
         print(repo)
@@ -606,12 +606,12 @@ def get_sources(source):
 
 
 def aggregate_reviews(sources, output_directory, github_password, github_token,
-                      github_username, tox, lp_credentials_store, lp_username, tox_jobs):
+                      github_username, tox, lp_credentials_store, tox_jobs):
     try:
         repos = []
         if 'lp-git' in sources:
             repos.extend(get_lp_repos(sources['lp-git'], output_directory,
-                                      lp_credentials_store, lp_username))
+                                      lp_credentials_store))
         if 'launchpad' in sources:
             # install time dependency on launchpad libs.
             from . import launchpadagent
@@ -741,16 +741,12 @@ def aggregate_reviews(sources, output_directory, github_password, github_token,
               required=False,
               help="An optional path to an already configured launchpad "
                    "credentials store.", default=None)
-@click.option('--lp-username', envvar='LAUNCHPAD_USERNAME', required=False,
-              help="Your launchpad username."
-                   "You can also set LAUNCHPAD_USERNAME as an environment "
-                   "variable.", default=None)
 @click.option('--tox-jobs', type=int, required=False, default=-1,
               help="Number of parallelized tox jobs. Default is -1, running "
                    "as many jobs as the processor allows. ")
 def main(config_skeleton, config, output_directory,
          github_username, github_password, github_token, poll,
-         tox, poll_interval, lp_credentials_store, lp_username, tox_jobs):
+         tox, poll_interval, lp_credentials_store, tox_jobs):
     """Start here."""
     global NOW
     if config_skeleton:
@@ -766,7 +762,7 @@ def main(config_skeleton, config, output_directory,
     sources = get_sources(config)
     aggregate_reviews(sources, output_directory, github_password,
                       github_token, github_username, tox,
-                      lp_credentials_store, lp_username, tox_jobs)
+                      lp_credentials_store, tox_jobs)
 
     if poll:
         # We do use time.sleep which is blocking so it is best to 'nice'
@@ -782,7 +778,7 @@ def main(config_skeleton, config, output_directory,
             NOW = localize_datetime(datetime.datetime.utcnow())
             aggregate_reviews(sources, output_directory, github_password,
                               github_token, github_username, tox,
-                              lp_credentials_store, lp_username, tox_jobs)
+                              lp_credentials_store)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR provides a simpler solution than #18; namely it utilizes recommended launchpad git configs (in which urls beginning with `lp:` are automatically converted to git-ssh syntax) to avoid needing to pass a username through CLI args.

As noted in the update to the README, `lp:` [substitution will now need to be set up in the host's .gitconfig](https://help.launchpad.net/Code/Git#Configuring_Git).

This PR reverts the functional commit from #18 .

I've tested these changes locally against a config.yaml including private repositories, along with an lp-enabled gitconfig. The build was successful.