### PR TITLE
fix: ensure the source git repo field of an MP is present before parsing

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -464,6 +464,7 @@ def get_mps(repo, branch, output_directory=None):
                     result = comment.vote
                     review_date = comment.date_created
 
+                if mp.source_git_repository_link is not None:
                     src_git_repo = mp.source_git_repository_link.replace(
                         'https://api.launchpad.net/devel/',
                         'lp:')


### PR DESCRIPTION
This PR handles the case where the `get_mps` function is used for bzr branches and therefore provides no git repo link.

I've tested with an exact copy of the "production" RG config.