### PR TITLE
Feature/review behind latest commit improvements

### DIFF
--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -469,9 +469,9 @@ def get_mps(repo, branch, output_directory=None):
                     cloned_head_date = cloned_repo.head.commit.committed_datetime.astimezone(pytz.utc)
         except GitCommandError:
             print("Warning: There was a problem cloning branch {} from {}."
-                  "The branch is likely missing. Attempts to determine if a review "
-                  "was submitted before subsequent changes have been pushed to the "
-                  "source branch."
+                  "The branch is likely missing. As such we are unable to determine "
+                  "if a review was submitted before subsequent changes have been "
+                  "pushed to the source branch."
                   .format(branch, src_git_repo))
 
         for vote in mp.votes:

--- a/src/review_gator/review_gator.py
+++ b/src/review_gator/review_gator.py
@@ -428,6 +428,7 @@ def get_candidate_mps(branch):
 def get_git_repo(path, checkout, tmpdir):
     cloned_repo = git_repo.clone_from(path, tmpdir, branch=checkout, multi_options=[
         '--single-branch',
+        '--no-checkout',
         '--depth=1',
     ])
 

--- a/src/review_gator/templates/reviews.html
+++ b/src/review_gator/templates/reviews.html
@@ -80,12 +80,15 @@
                             <tbody>
                                 {% for review in pull_request.reviews %}
                                 <tr {% if review.state == 'Approve' or review.state == 'APPROVED' %}class="success"{% endif %}
-                                    {% if review.state == 'Approve-STALE' or review.state == 'APPROVED-STALE' %}class="danger"{% endif %}
                                     {% if review.state == 'Disapprove' or review.state == 'Needs Fixing' or review.state == "CHANGES_REQUESTED" or review.state == "Resubmit" %}class="danger"{% endif %}
                                     {% if review.state == 'Needs Information' or review.state == 'COMMENTED' %}class="warning"{% endif %}>
                                     <td>{{ review.owner }}</td>
                                     <td>{{ review.state }}</td>
-                                    <td>{{ review.age }}</td>
+                                    <td>{{ review.age }}
+                                     {% if review.review_before_latest_commit %}
+                                        <i class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="left" title="Review submitted before latest commit in source branch. This may be due to a rebase or due to a subsequent change being pushed. As such the review may be considered stale and need re-review."></i>
+                                     {% endif %}
+                                    </td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
@@ -255,6 +258,8 @@
         });
 
         configureAutorefresh();
+
+        $('[data-toggle="tooltip"]').tooltip()
     } );
 
 </script>


### PR DESCRIPTION
fix: use more subtle aproach to highlighting potentially stale review

Also added a helpful tooltip to explain why the review might be stale.
fix: Use `--no-checkout` when cloning git repo as we don't need the content of the repo, only the git history
fix: Use new review_before_latest_commit Review property instead of "-STALE" string and only clone once per MP

We only need to clone repo once per MP, not for every vote/review.

I also moved to use a new review_before_latest_commit Review property instead of "-STALE" string

The temporary directory is now cleaned up too by using a context manager to create the dir for each clone.

Another fix required as part of this commit is making sure that the datetime comparisons are made using the same timezone.
