### PR TITLE
Fix invalid format and required version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.12"
-license = "GPL-3.0-only"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
 dependencies = [
     "babel",
     "click",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "fginther", email = "francis.ginther@canonical.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "babel",


### PR DESCRIPTION
it complains that license field does not have right format based on https://peps.python.org/pep-0621/#license.

also support python 3.8 for old build environment.
